### PR TITLE
Add support for picking render adapter

### DIFF
--- a/Common/Include/AdapterOption.h
+++ b/Common/Include/AdapterOption.h
@@ -1,0 +1,72 @@
+#pragma once
+
+// Anonymous namespace for usings
+namespace
+{
+    using namespace std;
+    using namespace Microsoft::IndirectDisp;
+    using namespace Microsoft::WRL;
+
+    struct AdapterOption
+    {
+        bool hasTargetAdapter{};
+        LUID adapterLuid{};
+
+        void load(const char* path)
+        {
+            ifstream ifs{ path };
+
+            if (!ifs.is_open())
+            {
+                return;
+            }
+
+            std::string line;
+            getline(ifs, line);
+
+            std::wstring target_name{ line.begin(), line.end() };
+
+            ComPtr<IDXGIFactory1> factory{};
+            if (!SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&factory))))
+            {
+                return;
+            }
+
+            for (UINT i = 0;; i++)
+            {
+                ComPtr<IDXGIAdapter> adapter{};
+                if (!SUCCEEDED(factory->EnumAdapters(i, &adapter)))
+                {
+                    break;
+                }
+
+                DXGI_ADAPTER_DESC desc;
+                if (!SUCCEEDED(adapter->GetDesc(&desc)))
+                {
+                    break;
+                }
+
+                // We found our target
+                if (_wcsicmp(target_name.c_str(), desc.Description) == 0)
+                {
+                    adapterLuid = desc.AdapterLuid;
+                    hasTargetAdapter = true;
+                }
+            }
+        }
+
+        void apply(const IDDCX_ADAPTER& adapter)
+        {
+            if (hasTargetAdapter)
+            {
+                if (IDD_IS_FUNCTION_AVAILABLE(IddCxAdapterSetRenderAdapter))
+                {
+                    IDARG_IN_ADAPTERSETRENDERADAPTER arg{};
+                    arg.PreferredRenderAdapter = adapterLuid;
+
+                    IddCxAdapterSetRenderAdapter(adapter, &arg);
+                }
+            }
+        }
+    };
+}

--- a/Virtual Display Driver (HDR)/IddSampleDriver/Driver.cpp
+++ b/Virtual Display Driver (HDR)/IddSampleDriver/Driver.cpp
@@ -22,6 +22,7 @@ Environment:
 #include<string>
 #include<tuple>
 #include<vector>
+#include <AdapterOption.h>
 
 using namespace std;
 using namespace Microsoft::IndirectDisp;
@@ -50,6 +51,10 @@ EVT_IDD_CX_ADAPTER_COMMIT_MODES2 IddSampleEvtIddCxAdapterCommitModes2;
 
 EVT_IDD_CX_MONITOR_SET_GAMMA_RAMP IddSampleEvtIddCxMonitorSetGammaRamp;
 
+struct
+{
+	AdapterOption Adapter;
+} Options;
 vector<tuple<int, int, int>> monitorModes;
 vector< DISPLAYCONFIG_VIDEO_SIGNAL_INFO> s_KnownMonitorModes2;
 UINT numVirtualDisplays;
@@ -150,6 +155,8 @@ NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
 	// redirects IoDeviceControl requests to an internal queue. This sample does not need this.
 	// IddConfig.EvtIddCxDeviceIoControl = IddSampleIoDeviceControl;
 	loadOptions("C:\\IddSampleDriver\\option.txt");
+	Options.Adapter.load("C:\\IddSampleDriver\\adapter.txt");
+
 	IddConfig.EvtIddCxAdapterInitFinished = IddSampleAdapterInitFinished;
 
 	IddConfig.EvtIddCxMonitorGetDefaultDescriptionModes = IddSampleMonitorGetDefaultModes;
@@ -244,6 +251,19 @@ HRESULT Direct3DDevice::Init()
 	{
 		return hr;
 	}
+
+#if 0 // Test code
+	{
+		FILE* file;
+		fopen_s(&file, "C:\\IddSampleDriver\\desc_hdr.bin", "wb");
+
+		DXGI_ADAPTER_DESC desc;
+		Adapter->GetDesc(&desc);
+
+		fwrite(&desc, 1, sizeof(desc), file);
+		fclose(file);
+	}
+#endif
 
 	// Create a D3D device using the render adapter. BGRA support is required by the WHQL test suite.
 	hr = D3D11CreateDevice(Adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0, D3D11_SDK_VERSION, &Device, nullptr, &DeviceContext);
@@ -536,6 +556,7 @@ void IndirectDeviceContext::InitAdapter()
 
 void IndirectDeviceContext::FinishInit()
 {
+	Options.Adapter.apply(m_Adapter);
 	for (unsigned int i = 0; i < numVirtualDisplays; i++) {
 		CreateMonitor(i);
 	}

--- a/Virtual Display Driver (HDR)/IddSampleDriver/IddSampleDriver.vcxproj
+++ b/Virtual Display Driver (HDR)/IddSampleDriver/IddSampleDriver.vcxproj
@@ -214,6 +214,7 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -226,6 +227,7 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -239,6 +241,7 @@
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
       <AdditionalOptions>/D_ATL_NO_WIN_SUPPORT /DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=4 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -255,6 +258,7 @@
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
       <AdditionalOptions>/D_ATL_NO_WIN_SUPPORT /DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=10 /DIDDCX_MINIMUM_VERSION_REQUIRED=3 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>

--- a/Virtual Display Driver (Non-HDR)/IddSampleDriver/Driver.cpp
+++ b/Virtual Display Driver (Non-HDR)/IddSampleDriver/Driver.cpp
@@ -22,6 +22,7 @@ Environment:
 #include<string>
 #include<tuple>
 #include<vector>
+#include <AdapterOption.h>
 
 using namespace std;
 using namespace Microsoft::IndirectDisp;
@@ -42,6 +43,10 @@ EVT_IDD_CX_MONITOR_QUERY_TARGET_MODES IddSampleMonitorQueryModes;
 EVT_IDD_CX_MONITOR_ASSIGN_SWAPCHAIN IddSampleMonitorAssignSwapChain;
 EVT_IDD_CX_MONITOR_UNASSIGN_SWAPCHAIN IddSampleMonitorUnassignSwapChain;
 
+struct
+{
+    AdapterOption Adapter;
+} Options;
 vector<tuple<int, int, int>> monitorModes;
 vector< DISPLAYCONFIG_VIDEO_SIGNAL_INFO> s_KnownMonitorModes2;
 UINT numVirtualDisplays;
@@ -122,6 +127,7 @@ void loadOptions(string filepath) {
     }
     monitorModes = res; return;
 }
+
 _Use_decl_annotations_
 NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
 {
@@ -141,7 +147,9 @@ NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
     // If the driver wishes to handle custom IoDeviceControl requests, it's necessary to use this callback since IddCx
     // redirects IoDeviceControl requests to an internal queue. This sample does not need this.
     // IddConfig.EvtIddCxDeviceIoControl = IddSampleIoDeviceControl;
+
     loadOptions("C:\\IddSampleDriver\\option.txt");
+    Options.Adapter.load("C:\\IddSampleDriver\\adapter.txt");
     IddConfig.EvtIddCxAdapterInitFinished = IddSampleAdapterInitFinished;
 
     IddConfig.EvtIddCxParseMonitorDescription = IddSampleParseMonitorDescription;
@@ -226,6 +234,19 @@ HRESULT Direct3DDevice::Init()
     {
         return hr;
     }
+
+#if 0 // Test code
+    {
+        FILE* file;
+        fopen_s(&file, "C:\\IddSampleDriver\\desc.bin", "wb");
+
+        DXGI_ADAPTER_DESC desc;
+        Adapter->GetDesc(&desc);
+
+        fwrite(&desc, 1, sizeof(desc), file);
+        fclose(file);
+    }
+#endif
 
     // Create a D3D device using the render adapter. BGRA support is required by the WHQL test suite.
     hr = D3D11CreateDevice(Adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0, D3D11_SDK_VERSION, &Device, nullptr, &DeviceContext);
@@ -488,6 +509,7 @@ void IndirectDeviceContext::InitAdapter()
 
 void IndirectDeviceContext::FinishInit()
 {
+    Options.Adapter.apply(m_Adapter);
     for (unsigned int i = 0; i < numVirtualDisplays; i++) {
         CreateMonitor(i);
     }

--- a/Virtual Display Driver (Non-HDR)/IddSampleDriver/IddSampleDriver.vcxproj
+++ b/Virtual Display Driver (Non-HDR)/IddSampleDriver/IddSampleDriver.vcxproj
@@ -52,6 +52,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>IddSampleDriver</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
@@ -101,6 +102,7 @@
     <IndirectDisplayDriver>true</IndirectDisplayDriver>
     <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
     <IDDCX_VERSION_MINOR>0</IDDCX_VERSION_MINOR>
+    <UMDF_VERSION_MINOR>27</UMDF_VERSION_MINOR>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -109,6 +111,7 @@
     <IndirectDisplayDriver>true</IndirectDisplayDriver>
     <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
     <IDDCX_VERSION_MINOR>0</IDDCX_VERSION_MINOR>
+    <UMDF_VERSION_MINOR>27</UMDF_VERSION_MINOR>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -116,8 +119,10 @@
     <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
     <IndirectDisplayDriver>true</IndirectDisplayDriver>
     <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
-    <IDDCX_VERSION_MINOR>0</IDDCX_VERSION_MINOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
+    <UMDF_VERSION_MINOR>31</UMDF_VERSION_MINOR>
+    <UMDF_MINIMUM_VERSION_REQUIRED>27</UMDF_MINIMUM_VERSION_REQUIRED>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -125,7 +130,9 @@
     <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
     <IndirectDisplayDriver>true</IndirectDisplayDriver>
     <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
-    <IDDCX_VERSION_MINOR>0</IDDCX_VERSION_MINOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+    <UMDF_VERSION_MINOR>31</UMDF_VERSION_MINOR>
+    <UMDF_MINIMUM_VERSION_REQUIRED>27</UMDF_MINIMUM_VERSION_REQUIRED>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -207,6 +214,7 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -219,6 +227,7 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -231,6 +240,8 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
@@ -243,6 +254,9 @@
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <ExceptionHandling>Async</ExceptionHandling>
       <EnablePREfast>true</EnablePREfast>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\Common\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>IDDCX_VERSION_MAJOR=1;IDDCX_VERSION_MINOR=4;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>


### PR DESCRIPTION
This PR adds support for selecting the render adapter through a file located at `C:\IddSampleDriver\adapter.txt`.
The feature is useful for devices with multiple GPUs (ie. laptops).

The behaviour is pretty straightforward. If the adapter specified is not found then it behaves the same way as it did before and leaves it up to the OS to select an adapter. And likewise if the running version of Windows doesn't support the API call.

Sample file:
[adapter.txt](https://github.com/itsmikethetech/Virtual-Display-Driver/files/15475303/adapter.txt)
