### PR TITLE
GPU fallback and XML

### DIFF
--- a/Common/Include/AdapterOption.h
+++ b/Common/Include/AdapterOption.h
@@ -1,5 +1,15 @@
 #pragma once
 
+#include <windows.h>
+#include <d3d11.h>
+#include <dxgi.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <wrl/client.h>
+
 // Anonymous namespace for usings
 namespace
 {
@@ -7,12 +17,22 @@ namespace
     using namespace Microsoft::IndirectDisp;
     using namespace Microsoft::WRL;
 
+    struct GPUInfo {
+        wstring name;
+        ComPtr<IDXGIAdapter> adapter;
+        DXGI_ADAPTER_DESC desc;
+    };
+
+    bool CompareGPUs(const GPUInfo& a, const GPUInfo& b) {
+        return a.desc.DedicatedVideoMemory > b.desc.DedicatedVideoMemory;
+    }
+
     struct AdapterOption
     {
         bool hasTargetAdapter{};
         LUID adapterLuid{};
 
-        void load(const char* path)
+        void load(const wchar_t* path)
         {
             ifstream ifs{ path };
 
@@ -53,6 +73,75 @@ namespace
                     hasTargetAdapter = true;
                 }
             }
+        }
+
+        wstring selectBestGPU() {
+            ComPtr<IDXGIFactory1> factory{};
+            if (!SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
+                return L"";
+            }
+
+            vector<GPUInfo> gpus;
+            for (UINT i = 0;; i++) {
+                ComPtr<IDXGIAdapter> adapter{};
+                if (!SUCCEEDED(factory->EnumAdapters(i, &adapter))) {
+                    break;
+                }
+
+                DXGI_ADAPTER_DESC desc;
+                if (!SUCCEEDED(adapter->GetDesc(&desc))) {
+                    continue;
+                }
+
+                GPUInfo info;
+                info.name = desc.Description;
+                info.adapter = adapter;
+                info.desc = desc;
+                gpus.push_back(info);
+            }
+
+            if (gpus.empty()) {
+                return L"";
+            }
+
+            sort(gpus.begin(), gpus.end(), CompareGPUs);
+
+            target_name = gpus.front().name;
+            adapterLuid = gpus.front().desc.AdapterLuid;
+            hasTargetAdapter = true;
+
+            return target_name;
+        }
+
+        void xmlprovide(wstring xtarg) {
+            target_name = xtarg;
+            ComPtr<IDXGIFactory1> factory{};
+            if (!SUCCEEDED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
+                return;
+            }
+
+            for (UINT i = 0;; i++) {
+                ComPtr<IDXGIAdapter> adapter{};
+                if (!SUCCEEDED(factory->EnumAdapters(i, &adapter))) {
+                    break;
+                }
+
+                DXGI_ADAPTER_DESC desc;
+                if (!SUCCEEDED(adapter->GetDesc(&desc))) {
+                    continue;
+                }
+
+                if (_wcsicmp(target_name.c_str(), desc.Description) == 0) {
+                    adapterLuid = desc.AdapterLuid;
+                    hasTargetAdapter = true;
+                    return;
+                }
+            }
+
+            if (!hasTargetAdapter) {
+                target_name = selectBestGPU();
+            }
+
         }
 
         void apply(const IDDCX_ADAPTER& adapter)


### PR DESCRIPTION
Here is the changes I did to AdapterOptions.h and Driver.cpp, To read settings xml and insert it into AdapterOptions.H from xmlvalue. if xml is not found, search for adapter.txt.

if wrong GPU name in either, autoselect the best one (vram based)

loadsettings is meant to replace loadoptions, but is not complete in this PR, since you asked for this in this order. So no fallback for missing xml or options.txt in this pr, these are also in the new load settings, but I cut it out to limit the size of this commit.

Error handling might be to "grade school" or not enough, since don't trust my error handling in this environment. So alot of the includs in AdapterOptions.h might be unneeded, but since I program from example and it worked for me i didn't remove them.